### PR TITLE
feat: 게시판 삭제 및 댓글개수측정

### DIFF
--- a/src/components/Board/BoardWrite.tsx
+++ b/src/components/Board/BoardWrite.tsx
@@ -59,7 +59,7 @@ function BoardWrite() {
     e.preventDefault();
     try {
       const query = collection(db, "Board");
-      await addDoc(query, {
+      const docRef = await addDoc(query, {
         author: newauthor,
         title: newTitle,
         category: newCategory,
@@ -76,7 +76,8 @@ function BoardWrite() {
       console.log("Content:", newContent);
       console.log("게시물이 성공적으로 추가되었습니다.");
 
-      navigate("/board");
+      const newPostId = docRef.id;
+      navigate(`/boarddetail/${newPostId}`);
       // 추가 후에 필요한 작업을 수행하거나 페이지를 리디렉션할 수 있습니다.
     } catch (error) {
       console.error("게시물 추가 중 오류 발생:", error);


### PR DESCRIPTION
## 작업내용

- 게시판 삭제 버튼. 사용자 와 작성자 같은 때만 버튼 표시.  댓글 개수 측정, 게시판 생성시 생성한 게시판 바로 이동.
  <br>

## 주요 변경점

- 작업 내용과 동일.
  <br>

## 유의할 점 (optional)

- 테스트할때 게시글 작성자와 동일한 아이디여야 테스트 가능합니다.
  <br>

## 클로즈

close #82 
